### PR TITLE
fix: memory and mongodb connection leak

### DIFF
--- a/internal/controllers/instance_controller_test.go
+++ b/internal/controllers/instance_controller_test.go
@@ -16,16 +16,16 @@ import (
 )
 
 // MockProvider returns a storage.Database for testing
-func MockProvider(ctx context.Context, instance v1beta1.GrowthbookInstance, username, password string) (storage.Database, error) {
+func MockProvider(ctx context.Context, instance v1beta1.GrowthbookInstance, username, password string) (storage.Disconnector, storage.Database, error) {
 	// See test "reconciling a GrowthbookInstance with a timeout"
 	if instance.Spec.Timeout != nil && instance.Spec.Timeout.Duration == 500*time.Millisecond {
 		<-ctx.Done()
-		return nil, ctx.Err()
+		return nil, nil, ctx.Err()
 	}
 
 	// For testing the controller logic the storage adapter just does nothing and returns no error
 	if instance.Spec.MongoDB.URI == "" {
-		return &growthbook.MockDatabase{
+		return &growthbook.MockDisconnect{}, &growthbook.MockDatabase{
 			FindOne: func(ctx context.Context, filter interface{}, dst interface{}) error {
 				return nil
 			},

--- a/internal/growthbook/storage_mock.go
+++ b/internal/growthbook/storage_mock.go
@@ -12,6 +12,13 @@ var (
 	_ storage.Collection = &MockCollection{}
 )
 
+type MockDisconnect struct {
+}
+
+func (d *MockDisconnect) Disconnect(ctx context.Context) error {
+	return nil
+}
+
 type MockDatabase struct {
 	FindOne    func(ctx context.Context, filter interface{}, dst interface{}) error
 	DeleteOne  func(ctx context.Context, filter interface{}) error

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -2,6 +2,10 @@ package storage
 
 import "context"
 
+type Disconnector interface {
+	Disconnect(ctx context.Context) error
+}
+
 type Database interface {
 	Collection(collName string) Collection
 }


### PR DESCRIPTION
## Current situation
The controller eventually uses all the connections from the service since the connections
are not disconnected after reconciliation.
Note this is also a memory leak since the connections are never terminated it might be the case that the controller
goes oom over time.

## Proposal
Correctly terminate any connections after reconciliation is done.
